### PR TITLE
Edit gem name to be 'decidim-liquidvoting'.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ base_path = "../" if File.basename(__dir__) == "development_app"
 require_relative "#{base_path}lib/decidim/liquidvoting/version"
 
 gem "decidim", Decidim::Liquidvoting::DECIDIM_VERSION
-gem "decidim-module-liquidvoting", path: "."
+gem "decidim-liquidvoting", path: "."
 gem "decidim-proposals", Decidim::Liquidvoting::DECIDIM_VERSION
 
 gem "bootsnap", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-module-liquidvoting (0.1)
+    decidim-liquidvoting (0.1)
       decidim-core (= 0.22.0)
       decidim-proposals (= 0.22.0)
       graphql-client (~> 0.16.0)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Space.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "decidim-module-liquidvoting", git: "https://github.com/liquidvotingio/decidim-module-liquidvoting"
+gem "decidim-liquidvoting", git: "https://github.com/liquidvotingio/decidim-module-liquidvoting"
 ```
 
 And then execute:

--- a/decidim-module-liquidvoting.gemspec
+++ b/decidim-module-liquidvoting.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/liquidvotingio/decidim-module-liquidvoting"
   s.required_ruby_version = ">= 2.6"
 
-  s.name = "decidim-module-liquidvoting"
+  s.name = "decidim-liquidvoting"
   s.summary = "A Decidim Liquidvoting module"
   s.description = "Integrates Decidim with liquidvoting.io."
 


### PR DESCRIPTION
These are the changes that got the demo working again for me, locally.

Tested in 'emulate-original-vote-button feature' branch by running
liquid-decidim-demo + our API, and seeing our new UI additions working.

I am unsure if we should also rename `decidim-module-liquidvoting.gemspec`
to be `decidim-liquidvoting.gemspec`, so I did not make this change.