### PR TITLE
Restructure delegation UI

### DIFF
--- a/app/views/decidim/liquidvoting/_delegation.html.erb
+++ b/app/views/decidim/liquidvoting/_delegation.html.erb
@@ -3,8 +3,8 @@
   <% if @lv_state.user_has_voted        # VOTED so disable delegation UI %>
     <%= content_tag :button, t("decidim.proposals.proposals.delegate_button.delegate"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
   <% elsif @lv_state.delegate_email     # NOT VOTED BUT DELEGATED so present undelegation UI -%>
-    You delegated to: <br>
-    <%= Decidim::User.find_by(email: @lv_state.delegate_email).name %>.
+    <%= t("decidim.proposals.proposals.delegation_ui.to") %>: <br>
+    <strong><%= Decidim::User.find_by(email: @lv_state.delegate_email).name %></strong>.
     <%= action_authorized_button_to(
       :undelegate,
       "#{proposal_path(proposal)}/delegations",
@@ -27,6 +27,7 @@
       <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
     <% end %>
   <% else                               # NOT VOTED NOT DELEGATED so present delegation UI %>
+    <%= t("decidim.proposals.proposals.delegation_ui.intro") %>: <br>
     <form action=<%= "#{proposal_path(proposal)}/delegations" %> method="POST" data-remote="true">
       <select name="delegate_email">
       <% (Decidim::User.where(admin: false).order(:name).pluck(:email, :name).unshift(["", "(choose delegate)"])).each do |email, name| %>

--- a/app/views/decidim/proposals/proposals/show.html.erb
+++ b/app/views/decidim/proposals/proposals/show.html.erb
@@ -99,8 +99,8 @@ extra_admin_link(
           <div class="card__content">
             <% if current_settings.votes_enabled? %>
               <%= render partial: "votes_count", locals: { proposal: @proposal, from_proposals_list: false } %>
-              <%= render partial: "decidim/liquidvoting/delegation", locals: { proposal: @proposal, from_proposals_list: false } %>
               <%= render partial: "vote_button", locals: { proposal: @proposal, from_proposals_list: false } %>
+              <%= render partial: "decidim/liquidvoting/delegation", locals: { proposal: @proposal, from_proposals_list: false } %>
             <% end %>
             <div class="row collapse buttons__row">
               <% if endorsements_enabled? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,9 +3,12 @@ en:
   decidim:
     proposals:
       proposals:
+        delegation_ui:
+          intro: Or delegate your support
+          to: You delegated to
         delegate_button:
-          delegate: Delegate support
-          withdraw: Withdraw
+          delegate: Delegate Support
+          withdraw: Withdraw Delegation
         vote_button:
           already_voted: Already supported
           already_voted_hover: Withdraw support


### PR DESCRIPTION
Based on [this discussion](https://github.com/liquidvotingio/decidim-module-liquidvoting/discussions/54), we've chosen to put the Support button under the Supports count, and then to introduce the Delegation interface with some text to set it off.

I keep the same color for the Delegate button as for Support, to make clear their association. 

I also now localize the the "Or delegate your support" and "You delegated to" text elements.

And finally I reworded the two versions of the Delegate button to strengthen the association with the Support button.

![image](https://user-images.githubusercontent.com/29486/110540846-4538f380-8127-11eb-8474-7b2f34a7b04a.png) ![image](https://user-images.githubusercontent.com/29486/110541072-89c48f00-8127-11eb-8c27-134fa8ec0c38.png) ![image](https://user-images.githubusercontent.com/29486/110540917-5da90e00-8127-11eb-91bd-33735a66dd11.png)

Closes #47 