### PR TITLE
Add @delegations_mode to proposals controller.

### DIFF
--- a/app/overrides/controllers/decidim/proposals/proposals_controller.rb
+++ b/app/overrides/controllers/decidim/proposals/proposals_controller.rb
@@ -50,6 +50,7 @@ module Decidim
 
         @lv_state = Decidim::Liquidvoting::Client.current_proposal_state(current_user&.email, proposal_url)
         @report_form = form(Decidim::ReportForm).from_params(reason: "spam")
+        @delegation_mode = "endorsements"
       end
 
       def new

--- a/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -5,6 +5,7 @@
     <%= render partial: "decidim/proposals/proposals/participatory_texts/proposal_vote_button", locals: { proposal: proposal, from_proposals_list: true } %>
   <% else %>
     <div id="proposal-<%= proposal.id %>-vote-button" class="button--vote-button">
+    <p>Delegation mode: <%= @delegation_mode %></p> <!-- check we can read the value -->
     <% if !current_user %>
       <% if current_settings.votes_blocked? %>
         <%= action_authorized_button_to :vote, t("decidim.proposals.proposals.vote_button.votes_blocked"), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), resource: proposal, class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>


### PR DESCRIPTION
Naive emulation of admin Proposals delegation_mode switch, for use in developing the 3 modes: off, supports, OR endorsements.

@delegation_mode added to `show` def / action.