### PR TITLE
Rename api call to :fetch_user_voted?

### DIFF
--- a/lib/decidim/liquidvoting.rb
+++ b/lib/decidim/liquidvoting.rb
@@ -21,7 +21,7 @@ module Decidim
     UserProposalState = Struct.new(:user_has_supported, :delegate_email)
 
     def self.user_proposal_state(user_email, proposal_url)
-      user_has_supported = Decidim::Liquidvoting::ApiClient.fetch_user_supported?(user_email, proposal_url)
+      user_has_supported = Decidim::Liquidvoting::ApiClient.fetch_user_voted?(user_email, proposal_url)
       delegate_email = Decidim::Liquidvoting::ApiClient.fetch_delegate_email(user_email, proposal_url)
 
       UserProposalState.new(user_has_supported, delegate_email)

--- a/lib/decidim/liquidvoting/api_client.rb
+++ b/lib/decidim/liquidvoting/api_client.rb
@@ -29,7 +29,7 @@ module Decidim
       SCHEMA = ::GraphQL::Client.load_schema(HTTP)
       CLIENT = ::GraphQL::Client.new(schema: SCHEMA, execute: HTTP)
 
-      def self.fetch_user_supported?(user_email, proposal_url)
+      def self.fetch_user_voted?(user_email, proposal_url)
         user_voted?(user_email, proposal_url)
       end
 

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -23,7 +23,7 @@ describe Decidim::Liquidvoting do
 
     before do
       # stub API
-      allow(Decidim::Liquidvoting::ApiClient).to receive(:fetch_user_supported?).and_return(true)
+      allow(Decidim::Liquidvoting::ApiClient).to receive(:fetch_user_voted?).and_return(true)
       allow(Decidim::Liquidvoting::ApiClient).to receive(:fetch_delegate_email).and_return(delegate.email)
     end
 


### PR DESCRIPTION
Our Decidim module has three layers or spaces when dealing with our Liquidvoting api:

1. the `ApiClient` - client code that calls our Liquidvoting api. It should be generic, without any Decidim-ness
2. the `Decidim::Liquidvoting` module - a kind of facade that wraps Liquidvoting activities like calling the api or bundling current api state. This is where we can map Liquidvoting-generic things like api calls to Decidim-specific terms
3. this Decidim module - it uses the `Decidim::Liquidvoting` module to get Liquidvoting things done

This PR is to remove the Decidim-specific term "support" from our `ApiClient`, yet preserve it in our `Liquidvoting` module facade/mapper.

Resolves #92 