### PR TITLE
Move api mutator calls into liquidvoting module

### DIFF
--- a/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
+++ b/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
@@ -28,11 +28,7 @@ module Decidim
       def destroy
         enforce_permission_to :unvote, :proposal, proposal: proposal
 
-        Decidim::Liquidvoting::ApiClient.delete_delegation(
-          proposal_url: proposal_locator.url,
-          delegator_email: delegator_email,
-          delegate_email: params[:delegate_email]
-        )
+        Liquidvoting.delete_delegation(delegator_email, params[:delegate_email], proposal)
 
         @from_proposals_list = params[:from_proposals_list] == "true"
         @proposals = [] + [proposal]

--- a/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
+++ b/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
@@ -10,11 +10,7 @@ module Decidim
       def create
         enforce_permission_to :vote, :proposal, proposal: proposal
 
-        Decidim::Liquidvoting::ApiClient.create_delegation(
-          proposal_url: proposal_locator.url,
-          delegator_email: delegator_email,
-          delegate_email: params[:delegate_email]
-        )
+        Liquidvoting.create_delegation(delegator_email, params[:delegate_email], proposal)
 
         @from_proposals_list = params[:from_proposals_list] == "true"
         @proposals = [] + [proposal]

--- a/app/overrides/commands/decidim/proposals/unvote_proposal.rb
+++ b/app/overrides/commands/decidim/proposals/unvote_proposal.rb
@@ -16,20 +16,13 @@ module Decidim
 
       # Executes the command. Broadcasts these events:
       #
-      # - :ok when everything is valid, together with the proposal.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :ok when everything is valid
       #
       # Returns nothing.
       def call
-        response = Decidim::Liquidvoting::ApiClient.delete_vote(
-          proposal_url: ResourceLocatorPresenter.new(@proposal).url,
-          participant_email: current_user.email
-        )
+        Liquidvoting.delete_vote(current_user.email, @proposal)
 
-        new_vote_count = response.voting_result&.in_favor
-        Liquidvoting.update_votes_count(@proposal, new_vote_count)
-
-        broadcast(:ok, @proposal)
+        broadcast(:ok)
       end
 
       private

--- a/app/overrides/commands/decidim/proposals/vote_proposal.rb
+++ b/app/overrides/commands/decidim/proposals/vote_proposal.rb
@@ -16,7 +16,7 @@ module Decidim
 
       # Executes the command. Broadcasts these events:
       #
-      # - :ok when everything is valid, together with the proposal vote.
+      # - :ok when everything is valid
       # - :invalid if the form wasn't valid and we couldn't proceed.
       #
       # Returns nothing.
@@ -28,16 +28,9 @@ module Decidim
         build_proposal_vote
         return broadcast(:invalid) unless vote.valid?
 
-        response = Decidim::Liquidvoting::ApiClient.create_vote(
-          proposal_url: ResourceLocatorPresenter.new(@proposal).url,
-          participant_email: current_user.email,
-          yes: true
-        )
+        Liquidvoting.create_vote(current_user.email, @proposal)
 
-        new_vote_count = response.voting_result&.in_favor
-        Liquidvoting.update_votes_count(@proposal, new_vote_count)
-
-        broadcast(:ok, vote)
+        broadcast(:ok)
       end
 
       attr_reader :vote

--- a/lib/decidim/liquidvoting.rb
+++ b/lib/decidim/liquidvoting.rb
@@ -41,6 +41,17 @@ module Decidim
       update_votes_count(proposal, new_count) if new_count
     end
 
+    def self.delete_delegation(delegator_email, delegate_email, proposal)
+      response = Decidim::Liquidvoting::ApiClient.delete_delegation(
+        proposal_url: ResourceLocatorPresenter.new(proposal).url,
+        delegator_email: delegator_email,
+        delegate_email: delegate_email
+      )
+      new_count = response&.voting_result&.in_favor
+
+      update_votes_count(proposal, new_count) if new_count
+    end
+
     # rubocop:disable Rails/SkipsModelValidations
     def self.update_votes_count(proposal, new_count)
       proposal.update_columns(proposal_votes_count: new_count)

--- a/lib/decidim/liquidvoting.rb
+++ b/lib/decidim/liquidvoting.rb
@@ -9,6 +9,14 @@ require "decidim/liquidvoting/logger"
 module Decidim
   # This namespace holds the logic of the `Liquidvoting` module
   module Liquidvoting
+    def self.create_vote(voter_email, proposal)
+      Decidim::Liquidvoting::ApiClient.create_vote(
+        proposal_url: ResourceLocatorPresenter.new(proposal).url,
+        participant_email: voter_email,
+        yes: true
+      )
+    end
+
     # rubocop:disable Rails/SkipsModelValidations
     def self.update_votes_count(proposal, new_count)
       proposal.update_columns(proposal_votes_count: new_count)

--- a/lib/decidim/liquidvoting.rb
+++ b/lib/decidim/liquidvoting.rb
@@ -52,15 +52,6 @@ module Decidim
       update_votes_count(proposal, new_count) if new_count
     end
 
-    # rubocop:disable Rails/SkipsModelValidations
-    def self.update_votes_count(proposal, new_count)
-      proposal.update_columns(proposal_votes_count: new_count)
-
-      msg = "TRACE: Liquidvoting.update_votes_count set #{new_count.inspect} for proposal id=#{proposal.id}"
-      Decidim::Liquidvoting::Logger.info msg
-    end
-    # rubocop:enable Rails/SkipsModelValidations
-
     UserProposalState = Struct.new(:user_has_supported, :delegate_email)
 
     def self.user_proposal_state(user_email, proposal_url)
@@ -69,6 +60,15 @@ module Decidim
 
       UserProposalState.new(user_has_supported, delegate_email)
     end
+
+    # rubocop:disable Rails/SkipsModelValidations
+    private_class_method def self.update_votes_count(proposal, new_count)
+      proposal.update_columns(proposal_votes_count: new_count)
+
+      msg = "TRACE: Liquidvoting.update_votes_count set #{new_count.inspect} for proposal id=#{proposal.id}"
+      Decidim::Liquidvoting::Logger.info msg
+    end
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end
 

--- a/lib/decidim/liquidvoting.rb
+++ b/lib/decidim/liquidvoting.rb
@@ -10,11 +10,14 @@ module Decidim
   # This namespace holds the logic of the `Liquidvoting` module
   module Liquidvoting
     def self.create_vote(voter_email, proposal)
-      Decidim::Liquidvoting::ApiClient.create_vote(
+      response = Decidim::Liquidvoting::ApiClient.create_vote(
         proposal_url: ResourceLocatorPresenter.new(proposal).url,
         participant_email: voter_email,
         yes: true
       )
+      new_count = response.voting_result&.in_favor
+
+      update_votes_count(proposal, new_count)
     end
 
     # rubocop:disable Rails/SkipsModelValidations

--- a/lib/decidim/liquidvoting.rb
+++ b/lib/decidim/liquidvoting.rb
@@ -20,6 +20,16 @@ module Decidim
       update_votes_count(proposal, new_count) if new_count
     end
 
+    def self.delete_vote(voter_email, proposal)
+      response = Decidim::Liquidvoting::ApiClient.delete_vote(
+        proposal_url: ResourceLocatorPresenter.new(proposal).url,
+        participant_email: voter_email
+      )
+      new_count = response&.voting_result&.in_favor
+
+      update_votes_count(proposal, new_count) if new_count
+    end
+
     # rubocop:disable Rails/SkipsModelValidations
     def self.update_votes_count(proposal, new_count)
       proposal.update_columns(proposal_votes_count: new_count)

--- a/lib/decidim/liquidvoting.rb
+++ b/lib/decidim/liquidvoting.rb
@@ -30,6 +30,17 @@ module Decidim
       update_votes_count(proposal, new_count) if new_count
     end
 
+    def self.create_delegation(delegator_email, delegate_email, proposal)
+      response = Decidim::Liquidvoting::ApiClient.create_delegation(
+        proposal_url: ResourceLocatorPresenter.new(proposal).url,
+        delegator_email: delegator_email,
+        delegate_email: delegate_email
+      )
+      new_count = response&.voting_result&.in_favor
+
+      update_votes_count(proposal, new_count) if new_count
+    end
+
     # rubocop:disable Rails/SkipsModelValidations
     def self.update_votes_count(proposal, new_count)
       proposal.update_columns(proposal_votes_count: new_count)

--- a/lib/decidim/liquidvoting.rb
+++ b/lib/decidim/liquidvoting.rb
@@ -15,9 +15,9 @@ module Decidim
         participant_email: voter_email,
         yes: true
       )
-      new_count = response.voting_result&.in_favor
+      new_count = response&.voting_result&.in_favor
 
-      update_votes_count(proposal, new_count)
+      update_votes_count(proposal, new_count) if new_count
     end
 
     # rubocop:disable Rails/SkipsModelValidations

--- a/lib/decidim/liquidvoting/api_client.rb
+++ b/lib/decidim/liquidvoting/api_client.rb
@@ -88,7 +88,7 @@ module Decidim
 
         raise response.errors.messages["data"].join(", ") if response.errors.any?
 
-        true
+        response.data.create_delegation
       end
 
       ## Example:
@@ -189,7 +189,10 @@ module Decidim
       CreateDelegationMutation = CLIENT.parse <<-GRAPHQL
         mutation($proposal_url: String!, $delegator_email: String!, $delegate_email: String!) {
           createDelegation(proposalUrl: $proposal_url, delegatorEmail: $delegator_email, delegateEmail: $delegate_email) {
-            id
+            votingResult {
+              inFavor
+              against
+            }
           }
         }
 

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -59,9 +59,11 @@ describe Decidim::Liquidvoting do
       subject.create_delegation(delegator.email, delegate.email, proposal)
     end
 
-    xit "updates the proposal count" do
-      # blocked on liquidvotingio/api#189
-      expect(proposal).to receive(:update_columns).with(proposal_votes_count: 45)
+    it "updates the proposal count" do
+      subject.create_vote(delegate.email, proposal)
+
+      expected_count = 2 # the delegate, who has voted, and the delegator, who is delegating to them
+      expect(proposal).to receive(:update_columns).with(proposal_votes_count: expected_count)
 
       subject.create_delegation(delegator.email, delegate.email, proposal)
     end

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -5,6 +5,28 @@ require "spec_helper"
 describe Decidim::Liquidvoting do
   subject { Decidim::Liquidvoting }
 
+  describe "#create_vote" do
+    # response = Decidim::Liquidvoting::ApiClient.create_vote(
+    #   proposal_url: ResourceLocatorPresenter.new(@proposal).url,
+    #   participant_email: current_user.email,
+    #   yes: true
+    # )
+    # before do
+    #   # stub API
+    #   allow(Decidim::Liquidvoting::ApiClient).to receive(:create_vote).and_return(true)
+    #   allow(Decidim::Liquidvoting::ApiClient).to receive(:fetch_delegate_email).and_return(delegate.email)
+    # end
+    let(:user) { create(:user) }
+    let(:proposal) { create(:proposal) }
+
+    it "forwards call to the api" do
+      expect(Decidim::Liquidvoting::ApiClient).to receive(:create_vote)
+
+      subject.create_vote(user.email, proposal)
+    end
+
+  end
+
   describe "#update_votes_count" do
     let(:proposal) { create(:proposal) }
     let(:new_vote_count) { 35 }

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -24,6 +24,28 @@ describe Decidim::Liquidvoting do
     end
   end
 
+  describe "#delete_vote" do
+    let(:user) { create(:user) }
+    let(:proposal) { create(:proposal) }
+
+    it "forwards call to the api" do
+      expect(Decidim::Liquidvoting::ApiClient).to receive(:delete_vote).with(
+        proposal_url: Decidim::ResourceLocatorPresenter.new(proposal).url, participant_email: user.email
+      )
+
+      subject.delete_vote(user.email, proposal)
+    end
+
+    it "updates the proposal count" do
+      subject.create_vote(user.email, proposal)
+      expect(proposal.proposal_votes_count).to eq(1)
+
+      expect(proposal).to receive(:update_columns).with(proposal_votes_count: 0)
+
+      subject.delete_vote(user.email, proposal)
+    end
+  end
+
   describe "#update_votes_count" do
     let(:proposal) { create(:proposal) }
     let(:new_vote_count) { 35 }

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -46,6 +46,27 @@ describe Decidim::Liquidvoting do
     end
   end
 
+  describe "#create_delegation" do
+    let(:delegator) { create(:user) }
+    let(:delegate) { create(:user) }
+    let(:proposal) { create(:proposal) }
+
+    it "forwards call to the api" do
+      expect(Decidim::Liquidvoting::ApiClient).to receive(:create_delegation).with(
+        proposal_url: Decidim::ResourceLocatorPresenter.new(proposal).url, delegator_email: delegator.email, delegate_email: delegate.email
+      )
+
+      subject.create_delegation(delegator.email, delegate.email, proposal)
+    end
+
+    xit "updates the proposal count" do
+      # blocked on liquidvotingio/api#189
+      expect(proposal).to receive(:update_columns).with(proposal_votes_count: 45)
+
+      subject.create_delegation(delegator.email, delegate.email, proposal)
+    end
+  end
+
   describe "#update_votes_count" do
     let(:proposal) { create(:proposal) }
     let(:new_vote_count) { 35 }

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -6,16 +6,6 @@ describe Decidim::Liquidvoting do
   subject { Decidim::Liquidvoting }
 
   describe "#create_vote" do
-    # response = Decidim::Liquidvoting::ApiClient.create_vote(
-    #   proposal_url: ResourceLocatorPresenter.new(@proposal).url,
-    #   participant_email: current_user.email,
-    #   yes: true
-    # )
-    # before do
-    #   # stub API
-    #   allow(Decidim::Liquidvoting::ApiClient).to receive(:create_vote).and_return(true)
-    #   allow(Decidim::Liquidvoting::ApiClient).to receive(:fetch_delegate_email).and_return(delegate.email)
-    # end
     let(:user) { create(:user) }
     let(:proposal) { create(:proposal) }
 
@@ -23,6 +13,12 @@ describe Decidim::Liquidvoting do
       expect(Decidim::Liquidvoting::ApiClient).to receive(:create_vote).with(
         proposal_url: Decidim::ResourceLocatorPresenter.new(proposal).url, participant_email: user.email, yes: true
       )
+
+      subject.create_vote(user.email, proposal)
+    end
+
+    it "updates the proposal count" do
+      expect(proposal).to receive(:update_columns).with(proposal_votes_count: 1)
 
       subject.create_vote(user.email, proposal)
     end

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -94,18 +94,6 @@ describe Decidim::Liquidvoting do
     end
   end
 
-  describe "#update_votes_count" do
-    let(:proposal) { create(:proposal) }
-    let(:new_vote_count) { 35 }
-    let(:expected_msg) { "TRACE: Liquidvoting.update_votes_count set #{new_vote_count} for proposal id=#{proposal.id}" }
-
-    it "logs the unexpected call" do
-      expect(Decidim::Liquidvoting::Logger).to receive(:info).with(expected_msg)
-
-      subject.update_votes_count(proposal, new_vote_count)
-    end
-  end
-
   describe "#user_proposal_state" do
     let(:user) { create(:user) }
     let(:delegate) { create(:user) }
@@ -126,6 +114,18 @@ describe Decidim::Liquidvoting do
       lv_state = Decidim::Liquidvoting.user_proposal_state(user.email, "https://url_1")
 
       expect(lv_state.delegate_email).to eq(delegate.email)
+    end
+  end
+
+  describe "Logging" do
+    let(:user) { create(:user) }
+    let(:proposal) { create(:proposal) }
+    let(:expected_msg) { /TRACE: Liquidvoting.update_votes_count set [0-9]+ for proposal id=#{proposal.id}/ }
+
+    it "logs updates to the vote count" do
+      expect(Decidim::Liquidvoting::Logger).to receive(:info).with(expected_msg)
+
+      subject.create_vote(user.email, proposal)
     end
   end
 end

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -20,11 +20,12 @@ describe Decidim::Liquidvoting do
     let(:proposal) { create(:proposal) }
 
     it "forwards call to the api" do
-      expect(Decidim::Liquidvoting::ApiClient).to receive(:create_vote)
+      expect(Decidim::Liquidvoting::ApiClient).to receive(:create_vote).with(
+        proposal_url: Decidim::ResourceLocatorPresenter.new(proposal).url, participant_email: user.email, yes: true
+      )
 
       subject.create_vote(user.email, proposal)
     end
-
   end
 
   describe "#update_votes_count" do


### PR DESCRIPTION
Motivation: simplify the usage pattern, and wrap Liquidvoting api calls together with the updating of the vote counter.

This moves all calls to the four api mutators out of controllers and commands, and into the `Decidim::Liquidvoting` module meant to centralise this kind of thing. So all calls to do Liquidvoting things now look like `Liquidvoting.some_method`, and `ApiClient` is fully wrapped there.

It additionally moves the proposal vote count update into the same wrapper calls, further simplifying the controllers and commands, and insuring that the api call doesn't happen without the vote update (it was not happening for delegations, see below).

Here's the old and new usage pattern (here, for `create_vote`, in the `VoteProposal` command):

![image](https://user-images.githubusercontent.com/29486/114181837-4a65aa00-9942-11eb-859f-ea8677e478df.png)


The specs for the new methods in `Decidim::Liquidvoting` focus on behavior, not state; no attempt is made to validate api results for example. Instead, we just assert that the new wrapper methods 1) send the appropriate message to `ApiClient` with the correct arguments, and 2) send a `Proposal#proposal_votes_count` message with the expected value.

I tackled this now so that further integration work (endorsements, etc) can copy the new pattern (or whatever new pattern comes out of this review).

Closes #95 

To update the vote count on `create_delegation`, I had to change the api response in the graphql query (now all modifiers return a `voting_result`), and also the api client response (which was systematically returning `true`).

Additionally, the create/destroy delegations were not recording the new vote count in the proposal; that is fixed here.

Resolves #94