### PR TITLE
Illustrate a different pattern for lv_state

### DIFF
--- a/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
+++ b/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
@@ -5,17 +5,17 @@ module Decidim
     class ProposalVoteDelegationsController < Decidim::Proposals::ApplicationController
       before_action :authenticate_user!
 
-      helper_method :proposal, :proposal_path, :proposal_proposal_vote_path
+      helper_method :proposal, :proposal_path, :proposal_proposal_vote_path, :lv_state
 
       def create
         enforce_permission_to :vote, :proposal, proposal: proposal
 
         Liquidvoting.create_delegation(delegator_email, params[:delegate_email], proposal)
+        refresh_lv_state
 
         @from_proposals_list = params[:from_proposals_list] == "true"
         @proposals = [] + [proposal]
 
-        @lv_state = Liquidvoting.user_proposal_state(delegator_email, proposal_locator.url)
         render "decidim/proposals/proposal_votes/update_buttons_and_counters"
       end
 
@@ -29,11 +29,11 @@ module Decidim
         enforce_permission_to :unvote, :proposal, proposal: proposal
 
         Liquidvoting.delete_delegation(delegator_email, params[:delegate_email], proposal)
+        refresh_lv_state
 
         @from_proposals_list = params[:from_proposals_list] == "true"
         @proposals = [] + [proposal]
 
-        @lv_state = Liquidvoting.user_proposal_state(delegator_email, proposal_locator.url)
         render "decidim/proposals/proposal_votes/update_buttons_and_counters"
       end
 
@@ -59,6 +59,15 @@ module Decidim
 
       def proposal_proposal_vote_path(_ignore)
         "#{proposal_path(nil)}/proposal_vote"
+      end
+
+      attr_reader :lv_state
+
+      # Retrieve the current liquidvoting state. The state is exposed as a helper method :lv_state.
+      # Since timing with regard to votes and delegations is important, make this a deliberate act,
+      # rather than a lazy memoized attribute.
+      def refresh_lv_state
+        @lv_state = Liquidvoting.user_proposal_state(delegator_email, proposal_locator.url)
       end
     end
   end

--- a/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
+++ b/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
@@ -5,13 +5,13 @@ module Decidim
     class ProposalVoteDelegationsController < Decidim::Proposals::ApplicationController
       before_action :authenticate_user!
 
-      helper_method :proposal, :proposal_path, :proposal_proposal_vote_path, :lv_state
+      helper_method :proposal, :proposal_path, :proposal_proposal_vote_path, :api_state
 
       def create
         enforce_permission_to :vote, :proposal, proposal: proposal
 
         Liquidvoting.create_delegation(delegator_email, params[:delegate_email], proposal)
-        refresh_lv_state
+        refresh_from_api
 
         @from_proposals_list = params[:from_proposals_list] == "true"
         @proposals = [] + [proposal]
@@ -29,7 +29,7 @@ module Decidim
         enforce_permission_to :unvote, :proposal, proposal: proposal
 
         Liquidvoting.delete_delegation(delegator_email, params[:delegate_email], proposal)
-        refresh_lv_state
+        refresh_from_api
 
         @from_proposals_list = params[:from_proposals_list] == "true"
         @proposals = [] + [proposal]
@@ -61,13 +61,13 @@ module Decidim
         "#{proposal_path(nil)}/proposal_vote"
       end
 
-      attr_reader :lv_state
+      attr_reader :api_state
 
-      # Retrieve the current liquidvoting state. The state is exposed as a helper method :lv_state.
+      # Retrieve the current liquidvoting state. The state is exposed as a helper method :api_state.
       # Since timing with regard to votes and delegations is important, make this a deliberate act,
       # rather than a lazy memoized attribute.
-      def refresh_lv_state
-        @lv_state = Liquidvoting.user_proposal_state(delegator_email, proposal_locator.url)
+      def refresh_from_api
+        @api_state = Liquidvoting.user_proposal_state(delegator_email, proposal_locator.url)
       end
     end
   end

--- a/app/views/decidim/liquidvoting/_delegation.html.erb
+++ b/app/views/decidim/liquidvoting/_delegation.html.erb
@@ -1,10 +1,10 @@
 <div id="proposal-<%= proposal.id %>-delegate-ui" class="button--vote-button">
 <% if current_user %>
-  <% if @lv_state.user_has_supported    # VOTED so disable delegation UI %>
+  <% if api_state.user_has_supported    # VOTED so disable delegation UI %>
     <%= content_tag :button, t("decidim.proposals.proposals.delegate_button.delegate"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
-  <% elsif @lv_state.delegate_email     # NOT VOTED BUT DELEGATED so present undelegation UI -%>
+  <% elsif api_state.delegate_email     # NOT VOTED BUT DELEGATED so present undelegation UI -%>
     <%= t("decidim.proposals.proposals.delegation_ui.to") %>: <br>
-    <strong><%= Decidim::User.find_by(email: @lv_state.delegate_email).name %></strong>.
+    <strong><%= Decidim::User.find_by(email: api_state.delegate_email).name %></strong>.
     <%= action_authorized_button_to(
       :undelegate,
       "#{proposal_path(proposal)}/delegations",
@@ -12,7 +12,7 @@
       method: :delete,
       remote: true,
       params: {
-        delegate_email: @lv_state.delegate_email,
+        delegate_email: api_state.delegate_email,
         proposal_id: proposal.id,
       },
       data: {

--- a/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -14,10 +14,10 @@
           <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
         <% end %>
       <% end %>
-    <% elsif @lv_state.delegate_email %>
+    <% elsif api_state.delegate_email %>
       <%= content_tag :button, t("decidim.proposals.proposals.vote_button.vote_delegated"), class: "button #{vote_button_classes(from_proposals_list)} disabled", id: "vote_button-#{proposal.id}", disabled: true %>
     <% else %>
-      <% if @lv_state.user_has_supported %>
+      <% if api_state.user_has_supported %>
         <%= action_authorized_button_to(
           :vote,
           proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list),

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -105,15 +105,15 @@ describe Decidim::Liquidvoting do
     end
 
     it "includes :user_has_supported" do
-      lv_state = Decidim::Liquidvoting.user_proposal_state(user.email, "https://url_1")
+      api_state = Decidim::Liquidvoting.user_proposal_state(user.email, "https://url_1")
 
-      expect(lv_state.user_has_supported).to be(true)
+      expect(api_state.user_has_supported).to be(true)
     end
 
     it "includes :delegate_email" do
-      lv_state = Decidim::Liquidvoting.user_proposal_state(user.email, "https://url_1")
+      api_state = Decidim::Liquidvoting.user_proposal_state(user.email, "https://url_1")
 
-      expect(lv_state.delegate_email).to eq(delegate.email)
+      expect(api_state.delegate_email).to eq(delegate.email)
     end
   end
 


### PR DESCRIPTION
This PR is to show and get feedback on a proposed common way to manage the LV state needed during a request.
It only shows the pattern for one controller and still needs to be applied to other controllers/commands/views.

Managing liquidvoting state in controllers and views is a little messy, and often (but inconsistently) uses a bare `@lv_state`.

The proposed usage pattern: controllers deliberately `refresh_lv_state` at the appropriate times (whenever that state will have changed, from votes or delegations), and then expose this state with a `lv_state` view helper. The `@lv_state` attribute would no longer be directly referenced.

So, thoughts about this being the standard idiom? Can anyone improve on the `lv_state` and `refresh_lv_state` names? I *think* it's best to make these things explicitly liquid voting, so that it's clear in views and controllers what is LV-related.