### PR TITLE
Stop exposing delegate emails

### DIFF
--- a/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
+++ b/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
@@ -48,11 +48,7 @@ module Decidim
       end
 
       def delegate_email
-        if params[:delegate_id].present?
-          User.find(params[:delegate_id])&.email
-        elsif params[:delegate_email].present?
-          params[:delegate_email]
-        end
+        User.find(params[:delegate_id])&.email
       end
 
       # Helpers for cross-engine routing

--- a/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
+++ b/app/controllers/decidim/liquidvoting/proposal_vote_delegations_controller.rb
@@ -10,7 +10,7 @@ module Decidim
       def create
         enforce_permission_to :vote, :proposal, proposal: proposal
 
-        Liquidvoting.create_delegation(delegator_email, params[:delegate_email], proposal)
+        Liquidvoting.create_delegation(delegator_email, delegate_email, proposal)
         refresh_from_api
 
         @from_proposals_list = params[:from_proposals_list] == "true"
@@ -28,7 +28,7 @@ module Decidim
       def destroy
         enforce_permission_to :unvote, :proposal, proposal: proposal
 
-        Liquidvoting.delete_delegation(delegator_email, params[:delegate_email], proposal)
+        Liquidvoting.delete_delegation(delegator_email, delegate_email, proposal)
         refresh_from_api
 
         @from_proposals_list = params[:from_proposals_list] == "true"
@@ -45,6 +45,14 @@ module Decidim
 
       def delegator_email
         current_user&.email
+      end
+
+      def delegate_email
+        if params[:delegate_id].present?
+          User.find(params[:delegate_id])&.email
+        elsif params[:delegate_email].present?
+          params[:delegate_email]
+        end
       end
 
       # Helpers for cross-engine routing

--- a/app/views/decidim/liquidvoting/_delegation.html.erb
+++ b/app/views/decidim/liquidvoting/_delegation.html.erb
@@ -1,7 +1,7 @@
 <div id="proposal-<%= proposal.id %>-delegate-ui" class="button--vote-button">
 <% if current_user %>
   <% if api_state.user_has_supported    # VOTED so disable delegation UI %>
-    <%= content_tag :button, t("decidim.proposals.proposals.delegate_button.delegate"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+    <%= content_tag :button, t("decidim.proposals.proposals.delegation_ui.delegate"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
   <% elsif api_state.delegate_email     # NOT VOTED BUT DELEGATED so present undelegation UI -%>
     <%= t("decidim.proposals.proposals.delegation_ui.to") %>: <br>
     <strong><%= Decidim::User.find_by(email: api_state.delegate_email).name %></strong>.
@@ -21,14 +21,18 @@
       },
       class: "button #{vote_button_classes(from_proposals_list)}",
     ) do %>
-      <%= t("decidim.proposals.proposals.delegate_button.withdraw") %>
+      <%= t("decidim.proposals.proposals.delegation_ui.withdraw") %>
       <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
     <% end %>
   <% else                               # NOT VOTED NOT DELEGATED so present delegation UI %>
     <%= t("decidim.proposals.proposals.delegation_ui.intro") %>: <br>
     <form action=<%= "#{proposal_path(proposal)}/delegations" %> method="POST" data-remote="true">
       <select name="delegate_id">
-      <% (Decidim::User.where(admin: false).order(:name).pluck(:id, :name).unshift(["", "(choose delegate)"])).each do |id, name| %>
+      <%
+        potential_delegates = Decidim::User.where(admin: false)
+        default_select = t("decidim.proposals.proposals.delegation_ui.default_select")
+        (potential_delegates.order(:name).pluck(:id, :name).unshift(["", "#{default_select}"])).each do |id, name|
+      %>
         <option value="<%= id %>"><%= name -%></option>
       <% end %>
       </select>
@@ -46,7 +50,7 @@
         },
         class: "button #{vote_button_classes(from_proposals_list)}",
       ) do %>
-        <%= t("decidim.proposals.proposals.delegate_button.delegate") %>
+        <%= t("decidim.proposals.proposals.delegation_ui.delegate") %>
         <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
       <% end %>
     </form>

--- a/app/views/decidim/liquidvoting/_delegation.html.erb
+++ b/app/views/decidim/liquidvoting/_delegation.html.erb
@@ -1,9 +1,9 @@
 <div id="proposal-<%= proposal.id %>-delegate-ui" class="button--vote-button">
 <% if current_user %>
   <% if api_state.user_has_supported    # VOTED so disable delegation UI %>
-    <%= content_tag :button, t("decidim.proposals.proposals.delegation_ui.delegate"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+    <%= content_tag :button, t("decidim.liquidvoting.delegation.delegate"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
   <% elsif api_state.delegate_id     # NOT VOTED BUT DELEGATED so present undelegation UI -%>
-    <%= t("decidim.proposals.proposals.delegation_ui.to") %>: <br>
+    <%= t("decidim.liquidvoting.delegation.to") %>: <br>
     <strong><%= Decidim::User.find(api_state.delegate_id).name %></strong>.
     <%= action_authorized_button_to(
       :undelegate,
@@ -21,16 +21,16 @@
       },
       class: "button #{vote_button_classes(from_proposals_list)}",
     ) do %>
-      <%= t("decidim.proposals.proposals.delegation_ui.withdraw") %>
+      <%= t("decidim.liquidvoting.delegation.withdraw") %>
       <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
     <% end %>
   <% else                               # NOT VOTED NOT DELEGATED so present delegation UI %>
-    <%= t("decidim.proposals.proposals.delegation_ui.intro") %>: <br>
+    <%= t("decidim.liquidvoting.delegation.intro") %>: <br>
     <form action=<%= "#{proposal_path(proposal)}/delegations" %> method="POST" data-remote="true">
       <select name="delegate_id">
       <%
         potential_delegates = Decidim::User.where(admin: false)
-        default_select = t("decidim.proposals.proposals.delegation_ui.default_select")
+        default_select = t("decidim.liquidvoting.delegation.default_select")
         (potential_delegates.order(:name).pluck(:id, :name).unshift(["", "#{default_select}"])).each do |id, name|
       %>
         <option value="<%= id %>"><%= name -%></option>
@@ -50,7 +50,7 @@
         },
         class: "button #{vote_button_classes(from_proposals_list)}",
       ) do %>
-        <%= t("decidim.proposals.proposals.delegation_ui.delegate") %>
+        <%= t("decidim.liquidvoting.delegation.delegate") %>
         <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
       <% end %>
     </form>

--- a/app/views/decidim/liquidvoting/_delegation.html.erb
+++ b/app/views/decidim/liquidvoting/_delegation.html.erb
@@ -2,9 +2,9 @@
 <% if current_user %>
   <% if api_state.user_has_supported    # VOTED so disable delegation UI %>
     <%= content_tag :button, t("decidim.proposals.proposals.delegation_ui.delegate"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
-  <% elsif api_state.delegate_email     # NOT VOTED BUT DELEGATED so present undelegation UI -%>
+  <% elsif api_state.delegate_id     # NOT VOTED BUT DELEGATED so present undelegation UI -%>
     <%= t("decidim.proposals.proposals.delegation_ui.to") %>: <br>
-    <strong><%= Decidim::User.find_by(email: api_state.delegate_email).name %></strong>.
+    <strong><%= Decidim::User.find(api_state.delegate_id).name %></strong>.
     <%= action_authorized_button_to(
       :undelegate,
       "#{proposal_path(proposal)}/delegations",
@@ -12,7 +12,7 @@
       method: :delete,
       remote: true,
       params: {
-        delegate_email: api_state.delegate_email,
+        delegate_id: api_state.delegate_id,
         proposal_id: proposal.id,
       },
       data: {

--- a/app/views/decidim/liquidvoting/_delegation.html.erb
+++ b/app/views/decidim/liquidvoting/_delegation.html.erb
@@ -27,9 +27,9 @@
   <% else                               # NOT VOTED NOT DELEGATED so present delegation UI %>
     <%= t("decidim.proposals.proposals.delegation_ui.intro") %>: <br>
     <form action=<%= "#{proposal_path(proposal)}/delegations" %> method="POST" data-remote="true">
-      <select name="delegate_email">
-      <% (Decidim::User.where(admin: false).order(:name).pluck(:email, :name).unshift(["", "(choose delegate)"])).each do |email, name| %>
-        <option value="<%= email %>"><%= name -%></option>
+      <select name="delegate_id">
+      <% (Decidim::User.where(admin: false).order(:name).pluck(:id, :name).unshift(["", "(choose delegate)"])).each do |id, name| %>
+        <option value="<%= id %>"><%= name -%></option>
       <% end %>
       </select>
       <%= action_authorized_button_to(

--- a/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -14,7 +14,7 @@
           <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
         <% end %>
       <% end %>
-    <% elsif api_state.delegate_email %>
+    <% elsif api_state.delegate_id %>
       <%= content_tag :button, t("decidim.proposals.proposals.vote_button.vote_delegated"), class: "button #{vote_button_classes(from_proposals_list)} disabled", id: "vote_button-#{proposal.id}", disabled: true %>
     <% else %>
       <% if api_state.user_has_supported %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,10 +4,10 @@ en:
     proposals:
       proposals:
         delegation_ui:
+          default_select: "(choose delegate)"
+          delegate: Delegate Support
           intro: Or delegate your support
           to: You delegated to
-        delegate_button:
-          delegate: Delegate Support
           withdraw: Withdraw Delegation
         vote_button:
           already_voted: Already supported

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,14 +1,15 @@
 ---
 en:
   decidim:
+    liquidvoting:
+      delegation:
+        default_select: "(choose delegate)"
+        delegate: Delegate Support
+        intro: Or delegate your support
+        to: You delegated to
+        withdraw: Withdraw Delegation
     proposals:
       proposals:
-        delegation_ui:
-          default_select: "(choose delegate)"
-          delegate: Delegate Support
-          intro: Or delegate your support
-          to: You delegated to
-          withdraw: Withdraw Delegation
         vote_button:
           already_voted: Already supported
           already_voted_hover: Withdraw support

--- a/lib/decidim/liquidvoting.rb
+++ b/lib/decidim/liquidvoting.rb
@@ -52,13 +52,15 @@ module Decidim
       update_votes_count(proposal, new_count) if new_count
     end
 
-    UserProposalState = Struct.new(:user_has_supported, :delegate_email)
+    UserProposalState = Struct.new(:user_has_supported, :delegate_id)
 
     def self.user_proposal_state(user_email, proposal_url)
       user_has_supported = Decidim::Liquidvoting::ApiClient.fetch_user_voted?(user_email, proposal_url)
       delegate_email = Decidim::Liquidvoting::ApiClient.fetch_delegate_email(user_email, proposal_url)
 
-      UserProposalState.new(user_has_supported, delegate_email)
+      delegate_id = Decidim::User.find_by(email: delegate_email)&.id if delegate_email.present?
+
+      UserProposalState.new(user_has_supported, delegate_id)
     end
 
     # rubocop:disable Rails/SkipsModelValidations

--- a/spec/lib/decidim/liquidvoting_spec.rb
+++ b/spec/lib/decidim/liquidvoting_spec.rb
@@ -110,10 +110,10 @@ describe Decidim::Liquidvoting do
       expect(api_state.user_has_supported).to be(true)
     end
 
-    it "includes :delegate_email" do
+    it "includes :delegate_id" do
       api_state = Decidim::Liquidvoting.user_proposal_state(user.email, "https://url_1")
 
-      expect(api_state.delegate_email).to eq(delegate.email)
+      expect(api_state.delegate_id).to eq(delegate.id)
     end
   end
 

--- a/spec/system/delegate_proposal_support_spec.rb
+++ b/spec/system/delegate_proposal_support_spec.rb
@@ -25,10 +25,10 @@ describe "Delegating support for a Proposal", type: :system do
   end
 
   it "works" do
-    select delegate.name, from: "delegate_email"
+    select delegate.name, from: "delegate_id"
     click_button "Delegate Support"
     expect(page).to have_button("Withdraw Delegation")
-    expect(page).not_to have_select("delegate_email")
+    expect(page).not_to have_select("delegate_id")
     expect(page).to have_text(:visible, /You delegated to: #{delegate.name}/, normalize_ws: true)
     expect(page).to have_button("Support", id: "vote_button-#{proposal.id}", disabled: true)
   end

--- a/spec/system/support_proposal_spec.rb
+++ b/spec/system/support_proposal_spec.rb
@@ -26,7 +26,7 @@ describe "Supporting a Proposal", type: :system do
   it "works" do
     click_button("Support", id: "vote_button-#{proposal.id}")
     expect(page).to have_button("Already supported")
-    expect(page).not_to have_select("delegate_email")
+    expect(page).not_to have_select("delegate_id")
     expect(page).to have_button("Delegate Support", disabled: true)
   end
 end

--- a/spec/system/undelegate_proposal_support_spec.rb
+++ b/spec/system/undelegate_proposal_support_spec.rb
@@ -22,7 +22,7 @@ describe "Undelegating support for a Proposal", type: :system do
   before do
     login_as user, scope: :user
     visit_proposal
-    select delegate.name, from: "delegate_email"
+    select delegate.name, from: "delegate_id"
     click_button "Delegate Support"
   end
 
@@ -30,7 +30,7 @@ describe "Undelegating support for a Proposal", type: :system do
     click_button "Withdraw Delegation"
     expect(page).to have_button("Support", id: "vote_button-#{proposal.id}")
     expect(page).to have_button("Delegate Support")
-    expect(page).to have_select("delegate_email")
+    expect(page).to have_select("delegate_id")
     expect(page).to have_text(:visible, /Or delegate your support:/)
   end
 end

--- a/spec/system/unsupport_proposal_spec.rb
+++ b/spec/system/unsupport_proposal_spec.rb
@@ -28,7 +28,7 @@ describe "Unsupporting a Proposal", type: :system do
     click_button("Already supported", id: "vote_button-#{proposal.id}")
     expect(page).to have_button("Support", id: "vote_button-#{proposal.id}")
     expect(page).to have_button("Delegate Support")
-    expect(page).to have_select("delegate_email")
+    expect(page).to have_select("delegate_id")
     expect(page).to have_text(:visible, /Or delegate your support:/)
   end
 end


### PR DESCRIPTION
This replaces the delegate email with their id in the select delegate dropdown (exposing email is a privacy issue).

It also makes the hardcoded default select text `(choose delegate)` a translateable field.

Finally, in order to remove delegate emails from the views entirely, I switched `api_state` to carry the delegate's id rather than email. While `api_state` never is rendered in the views, there was a form hidden field that was still email, and removing that encouraged me to remove emails altogether. 

So while email is still used both as an argument to the `Liquidvoting` module as well as to our api, the view rendering logic, and view contents are free of email.

I think delegator and delegate should be passed to `Liquidvoting` as `Decidim::User`s rather than their emails, that would separate the concept from how we techically communicate them to the api, but that's for another day :-)

Closes #100 