### PR TITLE
Bump rexml to 3.2.5 for CVE-2021-28965

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -671,7 +671,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)


### PR DESCRIPTION
Manual fix of a Dependabot security alert.

Dependabot failed to create a fixing PR so I'm doing that here. 

Read #111  for more detail.