### PR TITLE
Make live API the default config

### DIFF
--- a/lib/decidim/liquidvoting/api_client.rb
+++ b/lib/decidim/liquidvoting/api_client.rb
@@ -5,17 +5,29 @@ require "graphql/client/http"
 
 module Decidim
   module Liquidvoting
-    # Copied over from https://github.com/liquidvotingio/ruby-client/blob/master/liquid_voting_api.rb.
-    # Changes here will be applied there as well. Doing this for development speed, until
+    # Copied over from https://github.com/liquidvotingio/api-client/blob/master/liquid_voting_api.rb.
+    # Changes here will be applied there as well. Doing this for now for development speed, until
     # basics are ironed out and we can we publish the client as a gem.
 
     # This client integrates with the liquidvoting.io api, allowing for delegative voting
     # in a participatory space proposal.
     module ApiClient
-      URL = ENV.fetch("LIQUID_VOTING_API_URL", "http://localhost:4000")
-      # URL = ENV.fetch('LIQUID_VOTING_API_URL', 'https://api.liquidvoting.io')
+      # Default ENV vars configuring use of the live API with an AUTH_KEY for a demo organization.
+      #
+      # This default config works: the demo organization exists on the live API so one can easily test drive it.
+      #
+      # Deploying the liquidvoting API locally or within a private network works differently. Requests won't
+      # go through the live auth service, which would have exchanged the AUTH_KEY for an ORG_ID, so
+      # an AUTH_KEY isn't needed and an ORG_ID can be sent directly.
+      #
+      # Example:
+      #
+      # LIQUID_VOTING_API_URL = "http://localhost:4000"
+      # LIQUID_VOTING_API_ORG_ID = "24e173f5-d99a-4470-b1cc-142b392df10a"
+      #
+      URL = ENV.fetch("LIQUID_VOTING_API_URL", "https://api.liquidvoting.io")
       AUTH_KEY = ENV.fetch("LIQUID_VOTING_API_AUTH_KEY", "62309201-d2f0-407f-875b-9f836f94f2ca")
-      ORG_ID = ENV.fetch("LIQUID_VOTING_API_ORG_ID", "62309201-d2f0-407f-875b-9f836f94f2ca")
+      ORG_ID = ENV.fetch("LIQUID_VOTING_API_ORG_ID", "")
 
       HTTP = ::GraphQL::Client::HTTP.new(URL) do
         def headers(_context)


### PR DESCRIPTION
Things like precompiling assets or running migrations now barf if the liquidvoting api isn't accessible (the graphql client hits it to fetch the schema each time the code is loaded. Just got bit by this while trying to dockerize the demo.

~~this PR restricts the dependency to when the app is running in a server process~~ 

The server process detection approach is brittle: https://stackoverflow.com/questions/12088025/detect-if-application-was-started-as-http-server-or-not-rake-task-rconsole-etc/12246652#12246652

~~So instead we're going to let the api be hit in all cases, but distinguish between development and production/test. Loading the module will now hit the localhost api locally and when in development env, and the live api on production and CI.~~

The CI uses different environments, development (for rake test_app), test (for running tests on the test_app), and needs to hit the live api on both cases. 

I'm dropping the environment distinction and making the live API the default. Also adding more comments explaining the usage locally or private networks.

**Note**: 

With this solution, when running tests locally, by default it'll also hit the live api, and k8s teardown will need to be run manually. 

The alternative is to export the local env vars use the local api:

```bash
export LIQUID_VOTING_API_URL = "http://localhost:4000" 
export LIQUID_VOTING_API_ORG_ID = "24e173f5-d99a-4470-b1cc-142b392df10a"
sudo bin/rails s --port=80
```

The api teardown can be done by running `mix ecto.reset` on it.

In other words, I'm opting for keeping the module and CI configs straightforward, in exchange for an extra step in local dev.