### PR TITLE
Fix broken assembly proposal specs

### DIFF
--- a/lib/decidim/liquidvoting/engine.rb
+++ b/lib/decidim/liquidvoting/engine.rb
@@ -17,9 +17,9 @@ module Decidim
           post proposal_delegation_path => "proposal_vote_delegations#create", as: :delegations
           delete proposal_delegation_path => "proposal_vote_delegations#destroy"
 
-          # assembly_proposal_delegation_path = "/assemblies/:assembly_slug/f/:component_id/proposals/:id/delegations"
-          # post assembly_proposal_delegation_path => "proposal_vote_delegations#create", as: :assembly_delegations
-          # delete assembly_proposal_delegation_path => "proposal_vote_delegations#destroy"
+          assembly_proposal_delegation_path = "/assemblies/:assembly_slug/f/:component_id/proposals/:id/delegations"
+          post assembly_proposal_delegation_path => "proposal_vote_delegations#create", as: :assembly_delegations
+          delete assembly_proposal_delegation_path => "proposal_vote_delegations#destroy"
         end
       end
 

--- a/lib/decidim/liquidvoting/engine.rb
+++ b/lib/decidim/liquidvoting/engine.rb
@@ -17,9 +17,9 @@ module Decidim
           post proposal_delegation_path => "proposal_vote_delegations#create", as: :delegations
           delete proposal_delegation_path => "proposal_vote_delegations#destroy"
 
-          assembly_proposal_delegation_path = "/assemblies/:assembly_slug/f/:component_id/proposals/:id/delegations"
-          post assembly_proposal_delegation_path => "proposal_vote_delegations#create", as: :assembly_delegations
-          delete assembly_proposal_delegation_path => "proposal_vote_delegations#destroy"
+          # assembly_proposal_delegation_path = "/assemblies/:assembly_slug/f/:component_id/proposals/:id/delegations"
+          # post assembly_proposal_delegation_path => "proposal_vote_delegations#create", as: :assembly_delegations
+          # delete assembly_proposal_delegation_path => "proposal_vote_delegations#destroy"
         end
       end
 

--- a/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
@@ -12,7 +12,7 @@ describe "Delegating support for a Proposal", type: :system do
   let(:delegate) { create(:user, :confirmed, organization: organization) }
 
   def visit_proposal
-    visit resource_locator(assembly_proposal).path
+    visit resource_locator(assembly_proposal).url # path gives a RoutingError
   end
 
   before do

--- a/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
@@ -7,9 +7,9 @@ describe "Delegating support for a Proposal", type: :system do
   let(:assembly) { create(:assembly, organization: organization) }
   let(:assembly_proposals_component) do
     create(:component,
-      default_step_settings: { votes_enabled: true },
-      participatory_space: assembly,
-      manifest_name: :proposals)
+           default_step_settings: { votes_enabled: true },
+           participatory_space: assembly,
+           manifest_name: :proposals)
   end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 

--- a/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
@@ -5,7 +5,12 @@ require "spec_helper"
 describe "Delegating support for a Proposal", type: :system do
   let(:organization) { create(:organization) }
   let(:assembly) { create(:assembly, organization: organization) }
-  let(:assembly_proposals_component) { create(:component, participatory_space: assembly, manifest_name: :proposals) }
+  let(:assembly_proposals_component) do
+    create(:component,
+      default_step_settings: { votes_enabled: true },
+      participatory_space: assembly,
+      manifest_name: :proposals)
+  end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
   let(:user) { create(:user, :confirmed, organization: organization) }

--- a/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
@@ -3,19 +3,13 @@
 require "spec_helper"
 
 describe "Delegating support for a Proposal", type: :system do
-  include_context "with a component"
-  let!(:component) do
-    create(
-      :proposal_component,
-      :with_votes_enabled,
-      participatory_space: participatory_space
-    )
-  end
+  let(:organization) { create(:organization) }
+  let(:assembly) { create(:assembly, organization: organization) }
+  let(:assembly_proposals_component) { create(:component, participatory_space: assembly, manifest_name: :proposals) }
+  let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
-  let!(:user) { create(:user, :confirmed, organization: organization) }
-  let(:manifest_name) { :assemblies }
-  let!(:assembly_proposal) { create :proposal, component: component }
-  let!(:delegate) { create(:user, :confirmed, organization: organization) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+  let(:delegate) { create(:user, :confirmed, organization: organization) }
 
   def visit_proposal
     visit resource_locator(assembly_proposal).path

--- a/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/delegate_assembly_proposal_support_spec.rb
@@ -13,8 +13,8 @@ describe "Delegating support for a Proposal", type: :system do
   end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
-  let(:user) { create(:user, :confirmed, organization: organization) }
-  let(:delegate) { create(:user, :confirmed, organization: organization) }
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+  let!(:delegate) { create(:user, :confirmed, organization: organization) }
 
   def visit_proposal
     visit resource_locator(assembly_proposal).url # path gives a RoutingError

--- a/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
+++ b/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
@@ -11,7 +11,7 @@ describe "Supporting an Assembly Proposal", type: :system do
   let(:user) { create(:user, :confirmed, organization: organization) }
 
   def visit_assembly_proposal
-    visit resource_locator(assembly_proposal).path
+    visit resource_locator(assembly_proposal).url # path gives a RoutingError
   end
 
   before do

--- a/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
+++ b/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
@@ -21,6 +21,8 @@ describe "Supporting an Assembly Proposal", type: :system do
   end
 
   before do
+    expect(component.participatory_space_type).to eq("Decidim::Assembly")
+
     login_as user, scope: :user
     visit_assembly_proposal
   end

--- a/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
+++ b/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
@@ -3,25 +3,19 @@
 require "spec_helper"
 
 describe "Supporting an Assembly Proposal", type: :system do
-  include_context "with a component"
-  let!(:component) do
-    create(
-      :proposal_component,
-      :with_votes_enabled,
-      participatory_space: participatory_space
-    )
-  end
+  let(:organization) { create(:organization) }
+  let(:assembly) { create(:assembly, organization: organization) }
+  let(:assembly_proposals_component) { create(:component, participatory_space: assembly, manifest_name: :proposals) }
+  let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
-  let!(:user) { create(:user, :confirmed, organization: organization) }
-  let(:manifest_name) { :assemblies }
-  let!(:assembly_proposal) { create :proposal, component: component }
+  let(:user) { create(:user, :confirmed, organization: organization) }
 
   def visit_assembly_proposal
     visit resource_locator(assembly_proposal).path
   end
 
   before do
-    expect(component.participatory_space_type).to eq("Decidim::Assembly")
+    expect(assembly_proposal.component.participatory_space_type).to eq("Decidim::Assembly")
 
     login_as user, scope: :user
     visit_assembly_proposal

--- a/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
+++ b/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
@@ -7,10 +7,9 @@ describe "Supporting an Assembly Proposal", type: :system do
   let(:assembly) { create(:assembly, organization: organization) }
   let(:assembly_proposals_component) do
     create(:component,
-      # :with_votes_enabled,
-      participatory_space: assembly,
-      manifest_name: :proposals
-    )
+           default_step_settings: { votes_enabled: true },
+           participatory_space: assembly,
+           manifest_name: :proposals)
   end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 

--- a/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
+++ b/spec/system/assembly_proposals/support_assembly_proposal_spec.rb
@@ -5,7 +5,13 @@ require "spec_helper"
 describe "Supporting an Assembly Proposal", type: :system do
   let(:organization) { create(:organization) }
   let(:assembly) { create(:assembly, organization: organization) }
-  let(:assembly_proposals_component) { create(:component, participatory_space: assembly, manifest_name: :proposals) }
+  let(:assembly_proposals_component) do
+    create(:component,
+      # :with_votes_enabled,
+      participatory_space: assembly,
+      manifest_name: :proposals
+    )
+  end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
   let(:user) { create(:user, :confirmed, organization: organization) }
@@ -16,6 +22,7 @@ describe "Supporting an Assembly Proposal", type: :system do
 
   before do
     expect(assembly_proposal.component.participatory_space_type).to eq("Decidim::Assembly")
+    expect(assembly_proposal.component.current_settings.votes_enabled).to be(true)
 
     login_as user, scope: :user
     visit_assembly_proposal

--- a/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
@@ -13,8 +13,8 @@ describe "Undelegating support for a Proposal", type: :system do
   end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
-  let(:user) { create(:user, :confirmed, organization: organization) }
-  let(:delegate) { create(:user, :confirmed, organization: organization) }
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+  let!(:delegate) { create(:user, :confirmed, organization: organization) }
 
   def visit_proposal
     visit resource_locator(assembly_proposal).url # path gives a RoutingError

--- a/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
@@ -5,7 +5,12 @@ require "spec_helper"
 describe "Undelegating support for a Proposal", type: :system do
   let(:organization) { create(:organization) }
   let(:assembly) { create(:assembly, organization: organization) }
-  let(:assembly_proposals_component) { create(:component, participatory_space: assembly, manifest_name: :proposals) }
+  let(:assembly_proposals_component) do
+    create(:component,
+      default_step_settings: { votes_enabled: true },
+      participatory_space: assembly,
+      manifest_name: :proposals)
+  end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
   let(:user) { create(:user, :confirmed, organization: organization) }

--- a/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
@@ -7,9 +7,9 @@ describe "Undelegating support for a Proposal", type: :system do
   let(:assembly) { create(:assembly, organization: organization) }
   let(:assembly_proposals_component) do
     create(:component,
-      default_step_settings: { votes_enabled: true },
-      participatory_space: assembly,
-      manifest_name: :proposals)
+           default_step_settings: { votes_enabled: true },
+           participatory_space: assembly,
+           manifest_name: :proposals)
   end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 

--- a/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
@@ -3,19 +3,13 @@
 require "spec_helper"
 
 describe "Undelegating support for a Proposal", type: :system do
-  include_context "with a component"
-  let!(:component) do
-    create(
-      :proposal_component,
-      :with_votes_enabled,
-      participatory_space: participatory_space
-    )
-  end
+  let(:organization) { create(:organization) }
+  let(:assembly) { create(:assembly, organization: organization) }
+  let(:assembly_proposals_component) { create(:component, participatory_space: assembly, manifest_name: :proposals) }
+  let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
-  let!(:user) { create(:user, :confirmed, organization: organization) }
-  let(:manifest_name) { :assemblies }
-  let!(:assembly_proposal) { create :proposal, component: component }
-  let!(:delegate) { create(:user, :confirmed, organization: organization) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+  let(:delegate) { create(:user, :confirmed, organization: organization) }
 
   def visit_proposal
     visit resource_locator(assembly_proposal).path

--- a/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
+++ b/spec/system/assembly_proposals/undelegate_assembly_proposal_support_spec.rb
@@ -12,7 +12,7 @@ describe "Undelegating support for a Proposal", type: :system do
   let(:delegate) { create(:user, :confirmed, organization: organization) }
 
   def visit_proposal
-    visit resource_locator(assembly_proposal).path
+    visit resource_locator(assembly_proposal).url # path gives a RoutingError
   end
 
   before do

--- a/spec/system/assembly_proposals/unsupport_assembly_proposal_spec.rb
+++ b/spec/system/assembly_proposals/unsupport_assembly_proposal_spec.rb
@@ -5,7 +5,12 @@ require "spec_helper"
 describe "Unsupporting a Proposal", type: :system do
   let(:organization) { create(:organization) }
   let(:assembly) { create(:assembly, organization: organization) }
-  let(:assembly_proposals_component) { create(:component, participatory_space: assembly, manifest_name: :proposals) }
+  let(:assembly_proposals_component) do
+    create(:component,
+      default_step_settings: { votes_enabled: true },
+      participatory_space: assembly,
+      manifest_name: :proposals)
+  end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
   let(:user) { create(:user, :confirmed, organization: organization) }

--- a/spec/system/assembly_proposals/unsupport_assembly_proposal_spec.rb
+++ b/spec/system/assembly_proposals/unsupport_assembly_proposal_spec.rb
@@ -11,7 +11,7 @@ describe "Unsupporting a Proposal", type: :system do
   let(:user) { create(:user, :confirmed, organization: organization) }
 
   def visit_proposal
-    visit resource_locator(assembly_proposal).path
+    visit resource_locator(assembly_proposal).url # path gives a RoutingError
   end
 
   before do

--- a/spec/system/assembly_proposals/unsupport_assembly_proposal_spec.rb
+++ b/spec/system/assembly_proposals/unsupport_assembly_proposal_spec.rb
@@ -3,18 +3,12 @@
 require "spec_helper"
 
 describe "Unsupporting a Proposal", type: :system do
-  include_context "with a component"
-  let!(:component) do
-    create(
-      :proposal_component,
-      :with_votes_enabled,
-      participatory_space: participatory_space
-    )
-  end
+  let(:organization) { create(:organization) }
+  let(:assembly) { create(:assembly, organization: organization) }
+  let(:assembly_proposals_component) { create(:component, participatory_space: assembly, manifest_name: :proposals) }
+  let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 
-  let!(:user) { create(:user, :confirmed, organization: organization) }
-  let(:manifest_name) { :assemblies }
-  let!(:assembly_proposal) { create :proposal, component: component }
+  let(:user) { create(:user, :confirmed, organization: organization) }
 
   def visit_proposal
     visit resource_locator(assembly_proposal).path

--- a/spec/system/assembly_proposals/unsupport_assembly_proposal_spec.rb
+++ b/spec/system/assembly_proposals/unsupport_assembly_proposal_spec.rb
@@ -7,9 +7,9 @@ describe "Unsupporting a Proposal", type: :system do
   let(:assembly) { create(:assembly, organization: organization) }
   let(:assembly_proposals_component) do
     create(:component,
-      default_step_settings: { votes_enabled: true },
-      participatory_space: assembly,
-      manifest_name: :proposals)
+           default_step_settings: { votes_enabled: true },
+           participatory_space: assembly,
+           manifest_name: :proposals)
   end
   let(:assembly_proposal) { create :proposal, component: assembly_proposals_component }
 


### PR DESCRIPTION
In PR #118 we introduced four new specs meant to test that supporting and delegating also works for Assembly proposals, but we inadvertently built fixtures for Process proposals.

(see first commit that should have turned specs red, and second commit which explains why it didn't)

- [x] get the single red spec green by building an Assembly component
- [x] ~insure all four Assembly specs are red when we move them to Assembly components (because their routes are commented)~ Only the two delegation specs should break on absence of routes; confirmed this is true
- [x] uncomment routes, should be green now

There is an example of an Assembly component here: 633f0056ce5d64ad7d7f5aa101a3a2d9f4d4b6eb

Closes #43